### PR TITLE
fix a script call for character editor state

### DIFF
--- a/funkin/gameplay/character.lua
+++ b/funkin/gameplay/character.lua
@@ -231,7 +231,7 @@ end
 
 function Character:dance(force)
 	if self.__animations then
-		local result = self.script:call("dance")
+		local result = self.script and self.script:call("dance") or true
 		if result == nil then result = true end
 		if result then
 			if self.__animations["danceLeft"] and self.__animations["danceRight"] then


### PR DESCRIPTION
so, we know that characters are not allowed to use their scripts in the editor. one thing about the character, however, is that the coders forgot to check to see if the script exists to call a function, thus making the game crash instantly on the character editor state. i fixed it, but seems like the usage of loxel ui has to be remade.
![image](https://github.com/user-attachments/assets/2db4d232-99d0-41f6-99a8-b1a7f3a24e94)
